### PR TITLE
Swift 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
     build-and-test:
         macos:
-            xcode: "10.0.0"
+            xcode: "10.2.0"
         steps:
             - checkout
             - run:

--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -212,25 +212,25 @@
 			attributes = {
 				CLASSPREFIX = "";
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					146D72AB1AB782920058798C = {
 						CreatedOnToolsVersion = 6.2;
 						DevelopmentTeam = 29X3GG489T;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1020;
 					};
 					9F7AE1081DAE69AF00055D8D = {
 						CreatedOnToolsVersion = 8.1;
 						DevelopmentTeam = 29X3GG489T;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 				};
 			};
 			buildConfigurationList = 146D728E1AB782920058798C /* Build configuration list for PBXProject "Demo" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -293,6 +293,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -346,6 +347,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -406,7 +408,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_STYLE = debugging;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -423,7 +425,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sample.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_STYLE = debugging;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -453,7 +455,7 @@
 				STRIP_STYLE = debugging;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -483,7 +485,7 @@
 				PRODUCT_NAME = SweetSwift;
 				SKIP_INSTALL = YES;
 				STRIP_STYLE = debugging;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Demo.xcodeproj/xcshareddata/xcschemes/SweetSwift.xcscheme
+++ b/Demo.xcodeproj/xcshareddata/xcschemes/SweetSwift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/CollectionType+Sweetness.swift
+++ b/Sources/CollectionType+Sweetness.swift
@@ -1,7 +1,7 @@
 public extension Collection where Index == Int {
     typealias InternalElement = Iterator.Element
 
-    public func enumeratedWithCurrentAndNext() -> [(current: Iterator.Element, next: Iterator.Element)] {
+    func enumeratedWithCurrentAndNext() -> [(current: Iterator.Element, next: Iterator.Element)] {
         let count = self.count
         var enumeratedItems = [(InternalElement, InternalElement)]()
 

--- a/Sources/Date+Sweet.swift
+++ b/Sources/Date+Sweet.swift
@@ -7,7 +7,7 @@ public extension Date {
     ///   - calendar: The calendar to use to get the date components. Defaults to `Calendar.current`
     ///   - timeZone: The time zone to use with the calendar to get the date components. Defaults to `Calendar.current`.
     /// - Returns: The retrieved components.
-    public func components(_ components: Set<Calendar.Component>,
+    func components(_ components: Set<Calendar.Component>,
                            calendar: Calendar = .current,
                            timeZone: TimeZone = .current) -> DateComponents {
         var mutableCalendar = calendar
@@ -48,15 +48,15 @@ public extension Date {
     ///   - calendar: The calendar to use to create a date from the components. Defaults to `Calendar.current`.
     /// - Returns: The created date.
     /// - Throws: An error if a date could not be created
-    public static func from(day: Int,
-                            month: Int,
-                            year: Int,
-                            hour: Int = 0,
-                            minute: Int = 0,
-                            second: Int = 0,
-                            componentTimeZone: TimeZone = .current,
-                            calendarTimeZone: TimeZone = .current,
-                            calendar: Calendar = .current) throws -> Date {
+    static func from(day: Int,
+                     month: Int,
+                     year: Int,
+                     hour: Int = 0,
+                     minute: Int = 0,
+                     second: Int = 0,
+                     componentTimeZone: TimeZone = .current,
+                     calendarTimeZone: TimeZone = .current,
+                     calendar: Calendar = .current) throws -> Date {
         var components = DateComponents()
         components.day = day
         components.month = month

--- a/Sources/Int+Repetition.swift
+++ b/Sources/Int+Repetition.swift
@@ -3,7 +3,7 @@ public extension Int {
     /// Runs a closure the callee's number of times.
     ///
     /// - Parameter closure: The closure to execute
-    public func times(_ closure: () -> Void) {
+    func times(_ closure: () -> Void) {
         guard self > 0 else { return }
 
         for _ in 0 ..< self {
@@ -15,7 +15,7 @@ public extension Int {
     ///
     /// - Parameter closure: The closure to execute
     ///                      parameter: The zero-indexed current index of repetitions.
-    public func times(_ closure: (_ i: Int) -> Void) {
+    func times(_ closure: (_ i: Int) -> Void) {
         guard self > 0 else { return }
 
         for i in 0 ..< self {
@@ -27,7 +27,7 @@ public extension Int {
     ///
     /// - Parameter closure: The closure to run
     /// - Returns: The array of created items of the given type.
-    public func map<T>(_ closure: () -> T)  -> [T] {
+    func map<T>(_ closure: () -> T)  -> [T] {
         var items = [T]()
         for _ in 0..<self {
             let item = closure()
@@ -42,7 +42,7 @@ public extension Int {
     /// - Parameter closure: The closure to run
     ///                      parameter: The zero-indexed current index of repetitions.
     /// - Returns: The array of created items of the given type.
-    public func map<T>(_ closure: (_ i: Int) -> T)  -> [T] {
+    func map<T>(_ closure: (_ i: Int) -> T)  -> [T] {
         var items = [T]()
         for index in 0..<self {
             let item = closure(index)

--- a/Sources/Int+StringPadding.swift
+++ b/Sources/Int+StringPadding.swift
@@ -1,6 +1,6 @@
 public extension Int {
     
-    public enum ZeroPaddingError: Error {
+    enum ZeroPaddingError: Error {
         case invalidMinimumCharacterCount
         
         public var description: String {
@@ -16,7 +16,7 @@ public extension Int {
     /// - Parameter minimumCharacters: The minimum number of characters to display.
     /// - Returns: The zero-padded string.
     /// - Throws: An error if an invalid minimum number of characters is passed in (ie, zero or fewer)
-    public func zeroPaddedString(minimumCharacters: Int) throws -> String {
+    func zeroPaddedString(minimumCharacters: Int) throws -> String {
         guard minimumCharacters > 0 else {
             throw ZeroPaddingError.invalidMinimumCharacterCount
         }

--- a/SweetSwift.podspec
+++ b/SweetSwift.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "SweetSwift"
   s.summary          = "Helpers and sugar for Swift."
-  s.version          = "2.0.0"
+  s.version          = "3.0.0"
   s.homepage         = "https://github.com/BakkenBaeck/SweetSwift"
   s.license          = 'MIT'
   s.author           = { "Bakken & Bæck" => "post@UseSweet.no" }


### PR DESCRIPTION
Mostly just deleting `public` from public extensions since that's now redundant.

Note: Bumping to 3.0.0 since this would be a breaking change for anyone still on Swift 4.